### PR TITLE
feat(auth): Improve authentication

### DIFF
--- a/packages/univo/src/client.ts
+++ b/packages/univo/src/client.ts
@@ -1,5 +1,5 @@
 import type { Rpc } from ".";
-import { compress, getSignature } from "./utils";
+import { compress, raise } from "./utils";
 import { createException, getException } from "./exceptions";
 
 type Request<M extends keyof Rpc> = {
@@ -16,9 +16,6 @@ type Response<M extends keyof Rpc> = {
 	error?: { code: number; message: string };
 };
 
-// Chosen based on limited testing. May need tuning.
-const MIN_GZIP_SIZE = 1024;
-
 function http(url: string, opts: { signingKey?: string } = {}) {
 	return {
 		async request<M extends keyof Rpc>({ jsonrpc, id, method, params }: Request<M>): Promise<Response<M>> {
@@ -29,23 +26,13 @@ function http(url: string, opts: { signingKey?: string } = {}) {
 				headers.set("Content-Type", "application/json");
 
 				if (method.startsWith("private_")) {
+					// Authenticate request
 					if (opts.signingKey === undefined) throw new Error(ClientUnauthorizedError);
+					headers.set("Authorization", `Bearer ${opts.signingKey}`);
 
-					// Compress large requests
-					if (body.length > MIN_GZIP_SIZE) {
-						body = await compress(body).catch((cause) => {
-							throw new Error(ClientCompressionError, { cause });
-						});
-
-						headers.set("Content-Encoding", "gzip");
-					}
-
-					// Attach signature for compressed body
-					const signature = await getSignature({ key: opts.signingKey, body }).catch((cause) => {
-						throw new Error(ClientSignatureError, { cause });
-					});
-
-					headers.set("X-Univo-Signature", signature);
+					// Compress request
+					body = await compress(body).catch((cause) => raise(ClientCompressionError, { cause }));
+					headers.set("Content-Encoding", "gzip");
 				}
 
 				const res = await fetch(url, { headers, body, method: "POST" }).catch((cause) => {
@@ -66,7 +53,6 @@ function http(url: string, opts: { signingKey?: string } = {}) {
 const ClientCompressionError = createException("An error occurred when compressing the request");
 const ClientConnectionError = createException("An errored occurred when connecting to the server");
 const ClientResponseError = createException("An error occurred when reading the servers response");
-const ClientSignatureError = createException("An error occurred with the outgoing request signature");
 const ClientUnauthorizedError = createException("Attempted to execute a private method without providing a request signing key");
 
 export { http };

--- a/packages/univo/src/index.ts
+++ b/packages/univo/src/index.ts
@@ -1,7 +1,7 @@
 import type { Flatten } from "./utils";
 import { version } from "../package.json";
 import { catchException, createException, getException } from "./exceptions";
-import { retry, nonNullable, getSignature, createLogger, verifySignature, hexToNumber, isAddressEqual, decompress } from "./utils";
+import { retry, nonNullable, getSignature, createLogger, hexToNumber, isAddressEqual, decompress, decoder } from "./utils";
 
 // Block ------------------------------------------------------------------------------------------------------------------------------------
 // This is the minimum set of block fields univo needs to function. These are mostly required to allow to perform
@@ -730,28 +730,33 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 		}
 
 		// Determine authentication status
-		let authenticated = false;
-
-		const signature = req.headers.get("X-Univo-Signature");
-
-		if (signature) {
-			try {
-				authenticated = await verifySignature({ key: opts.signingKey, body: body_buffer, signature });
-			} catch {
-				return Response.json(
-					{ jsonrpc: "2.0", id: null, error: { code: 0, message: "Failed to verify request signature" } }, //
-					{ status: 400 },
-				);
-			}
-		}
+		const authorization = req.headers.get("Authorization");
+		const authenticated = authorization === `Bearer ${opts.signingKey}`;
 
 		// Decode request body
 		let body_string: string;
 
 		if (req.headers.get("Content-Encoding") === "gzip") {
+			// Compressed requests should be authenticated before decompression. This prevents unauthenticated clients
+			// from sending ZIP bombs that force the server to spend CPU and memory before rejecting the request.
+
+			if (!authorization) {
+				return Response.json(
+					{ jsonrpc: "2.0", id: null, error: { code: 0, message: "No bearer token provided" } }, //
+					{ status: 400 },
+				);
+			}
+
+			if (!authenticated) {
+				return Response.json(
+					{ jsonrpc: "2.0", id: null, error: { code: 0, message: "Invalid bearer token" } }, //
+					{ status: 400 },
+				);
+			}
+
 			body_string = await decompress(body_buffer);
 		} else {
-			body_string = new TextDecoder().decode(body_buffer);
+			body_string = decoder.decode(body_buffer);
 		}
 
 		// Parse request as JSON
@@ -766,24 +771,24 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 			);
 		}
 
-		// Authorize request
+		// Authorize request for any private methods
 		if (json.method.startsWith("private_")) {
-			if (!signature) {
+			if (!authorization) {
 				return Response.json(
-					{ jsonrpc: "2.0", id: json.id, error: { code: 0, message: "No request signature provided" } }, //
+					{ jsonrpc: "2.0", id: json.id, error: { code: 0, message: "No bearer token provided" } }, //
 					{ status: 400 },
 				);
 			}
 
-			if (!authenticated) {
+			if (authorization !== `Bearer ${opts.signingKey}`) {
 				return Response.json(
-					{ jsonrpc: "2.0", id: json.id, error: { code: 0, message: "Invalid request signature" } }, //
+					{ jsonrpc: "2.0", id: json.id, error: { code: 0, message: "Invalid bearer token" } }, //
 					{ status: 400 },
 				);
 			}
 		}
 
-		// Peform RPC
+		// Perform RPC
 		try {
 			if (rpc[json.method as keyof Rpc] === undefined) throw new Error(UnknownMethodError);
 

--- a/packages/univo/src/utils.ts
+++ b/packages/univo/src/utils.ts
@@ -167,3 +167,5 @@ export async function decompress(input: ArrayBuffer): Promise<string> {
 	const decompressed = new Blob([input]).stream().pipeThrough(new DecompressionStream("gzip"));
 	return new Response(decompressed).text();
 }
+
+export const decoder = new TextDecoder();


### PR DESCRIPTION
This changes authentication from a HMAC based scheme to simple Bearer tokens.

1. This allows us to drop non-standard usage of the `X-Univo-Signature` header in favour of an `Authorization` header. That improves compatibility with so many existing tools.

2. HMAC doesn't work well with streaming. Most schemes that forces a signature over the payload itself forces clients to buffer the entire payload into memory before any of the body can be sent. Note that there are advanced schemes that allow for signing chunks of the payload but the complexity of the schemes are not worth it in my opinion.

The primary trade-off here is that we no longer get request-integrity. This primary reason why this is okay is because I want to broaden the scope of payload integrity from "is this payload valid within the context of the current request" to "is this payload valid blockchain data in the context of the canonical chain state". The current HMAC scheme solves the former when the long-term goal we really want to achieve is the latter. Research is well under way for how I can achieve the latter but those ideas are for a later upgrade.