### PR TITLE
feat(metadata): Add KV metadata storage

### DIFF
--- a/packages/univo/package.json
+++ b/packages/univo/package.json
@@ -51,5 +51,8 @@
 		"unbuild": "^3.5.0",
 		"viem": "2.45.1",
 		"vitest": "^3.1.3"
+	},
+	"peerDependencies": {
+		"unstorage": ">=1"
 	}
 }

--- a/packages/univo/src/index.test.ts
+++ b/packages/univo/src/index.test.ts
@@ -1,4 +1,5 @@
 import { http } from "msw";
+import { createStorage } from "unstorage";
 import { expect, test, assert } from "vitest";
 
 import { indexer } from ".";
@@ -8,7 +9,7 @@ import { hexToNumber, numberToHex } from "./utils";
 import { test_Block, test_getBlock, test_indexer } from "../tests/utils";
 
 test.concurrent("correctly infers the event type", () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	const event = univo.event({
 		id: "test",
@@ -27,7 +28,7 @@ test.concurrent("correctly infers the event type", () => {
 });
 
 test.concurrent("throws an error if an event with an invalid id is defined", () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	expect(() => {
 		univo.event({
@@ -40,7 +41,7 @@ test.concurrent("throws an error if an event with an invalid id is defined", () 
 });
 
 test("public_writeAndReturnBlocks reports no results when provided a block that matches no event filters", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -71,7 +72,7 @@ test("public_writeAndReturnBlocks reports no results when provided a block that 
 });
 
 test("public_writeAndReturnBlocks reports ok results if we return an empty handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -120,7 +121,7 @@ test("public_writeAndReturnBlocks reports ok results if we return an empty handl
 test("public_writeAndReturnBlocks reports ok results if we successfully upsert events", async () => {
 	const upserted: any[] = [];
 
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -176,6 +177,7 @@ test("public_writeAndReturnBlocks reports a block_error for all events when fail
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
+		metadataStorage: createStorage(),
 		getBlock: async () => {
 			throw new Error("Failed to load block");
 		},
@@ -243,7 +245,7 @@ test("public_writeAndReturnBlocks reports a block_error for all events when fail
 });
 
 test("public_writeAndReturnBlocks reports a handler_error", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -292,7 +294,7 @@ test("public_writeAndReturnBlocks reports a handler_error", async () => {
 });
 
 test("public_writeAndReturnBlocks reports any upsert errors", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -344,7 +346,7 @@ test("public_writeAndReturnBlocks reports any upsert errors", async () => {
 
 test("public_writeAndReturnBlocks retries upsert errors", async () => {
 	let count = 0;
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -392,7 +394,7 @@ test("public_writeAndReturnBlocks deduplicates events with the same storage adap
 		},
 	};
 
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		storage,
@@ -437,7 +439,7 @@ test("public_writeAndReturnBlocks deduplicates events with the same storage adap
 });
 
 test("public_writeAndReturnBlocks returns blocks", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -479,7 +481,7 @@ test("public_writeAndReturnBlocks returns blocks", async () => {
 });
 
 test("public_writeAndReturnBlocks only returns blocks it successfully loaded", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -521,7 +523,7 @@ test("public_writeAndReturnBlocks only returns blocks it successfully loaded", a
 });
 
 test.concurrent("public_deleteBlock rejects invalid blocks", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	expect(async () => {
 		await test_indexer(univo).request({
@@ -535,7 +537,7 @@ test("public_deleteBlock never deletes events from canonical blocks", async () =
 	let deleted = false;
 	let upserted = false;
 
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -595,6 +597,7 @@ test("public_deleteBlock deletes events from reorganised blocks", async () => {
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
+		metadataStorage: createStorage(),
 		getBlock: async () => {
 			// The first request happens we are writing a block and we want this to be the reorganised block
 			if (upserted === false) {
@@ -669,7 +672,7 @@ test("private_writeEvents indexes only the events requested", async () => {
 	const upserted: any[] = [];
 	let event2HandlerCalled = false;
 
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "event1",
@@ -720,7 +723,7 @@ test.concurrent("private_writeEvents deduplicates events with the same storage a
 		},
 	};
 
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		storage,
@@ -756,7 +759,7 @@ test.concurrent("private_writeEvents deduplicates events with the same storage a
 });
 
 test.concurrent("private_writeEvents records events", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -781,7 +784,7 @@ test.concurrent("private_writeEvents records events", async () => {
 });
 
 test.concurrent("private_writeEvents ignores events not explicitly requested", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -814,7 +817,7 @@ test.concurrent("private_writeEvents ignores events not explicitly requested", a
 });
 
 test.concurrent("private_writeEvents returns handler errors", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -856,7 +859,7 @@ test.concurrent("private_writeEvents returns handler errors", async () => {
 });
 
 test.concurrent("private_writeEvents returns errors thrown during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -913,7 +916,7 @@ test.concurrent("private_writeEvents returns errors thrown during upsert", async
 
 test.concurrent("private_writeEvents retries upsert errors", async () => {
 	let count = 0;
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -972,7 +975,7 @@ test.concurrent("private_writeEvents retries upsert errors", async () => {
 });
 
 test.concurrent("private_writeEvents only returns the handler error if both handler and upsert fail", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1030,7 +1033,7 @@ test.concurrent("private_writeEvents only returns the handler error if both hand
 });
 
 test.concurrent("private_writeEvents returns incomplete errors in handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1088,7 +1091,7 @@ test.concurrent("private_writeEvents returns incomplete errors in handler", asyn
 });
 
 test.concurrent("private_writeEvents returns swallowed incomplete errors in handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1152,7 +1155,7 @@ test.concurrent("private_writeEvents returns swallowed incomplete errors in hand
 });
 
 test.concurrent("private_writeEvents returns incomplete errors in upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1214,7 +1217,7 @@ test.concurrent("private_writeEvents returns incomplete errors in upsert", async
 });
 
 test.concurrent("private_writeEvents returns swallowed incomplete errors in upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1279,7 +1282,7 @@ test.concurrent("private_writeEvents returns swallowed incomplete errors in upse
 });
 
 test.concurrent("private_writeEvents doesn't return an error when accessing a provided null property", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1319,7 +1322,7 @@ test.concurrent("private_writeEvents doesn't return an error when accessing a pr
 });
 
 test.concurrent("private_writeEvents never upserts if handler returns empty event list", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1353,7 +1356,7 @@ test("private_writeEventsAndGetKeys indexes only the events requested", async ()
 	const upserted: any[] = [];
 	let event2HandlerCalled = false;
 
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "event1",
@@ -1399,7 +1402,7 @@ test("private_writeEventsAndGetKeys indexes only the events requested", async ()
 });
 
 test.concurrent("private_writeEventsAndGetKeys never upserts if handler returns empty event list", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1432,7 +1435,7 @@ test.concurrent("private_writeEventsAndGetKeys never upserts if handler returns 
 });
 
 test.concurrent("private_writeEventsAndGetKeys records minimum keys from matching filters", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1467,7 +1470,7 @@ test.concurrent("private_writeEventsAndGetKeys records minimum keys from matchin
 });
 
 test.concurrent("private_writeEventsAndGetKeys records block keys during handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1503,7 +1506,7 @@ test.concurrent("private_writeEventsAndGetKeys records block keys during handler
 });
 
 test.concurrent("private_writeEventsAndGetKeys records transaction keys during handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1543,7 +1546,7 @@ test.concurrent("private_writeEventsAndGetKeys records transaction keys during h
 });
 
 test.concurrent("private_writeEventsAndGetKeys records withdrawals keys during handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1583,7 +1586,7 @@ test.concurrent("private_writeEventsAndGetKeys records withdrawals keys during h
 });
 
 test.concurrent("private_writeEventsAndGetKeys records receipt keys during handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1623,7 +1626,7 @@ test.concurrent("private_writeEventsAndGetKeys records receipt keys during handl
 });
 
 test.concurrent("private_writeEventsAndGetKeys records log keys during handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1665,7 +1668,7 @@ test.concurrent("private_writeEventsAndGetKeys records log keys during handler",
 });
 
 test.concurrent("private_writeEventsAndGetKeys records block keys during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1706,7 +1709,7 @@ test.concurrent("private_writeEventsAndGetKeys records block keys during upsert"
 });
 
 test.concurrent("private_writeEventsAndGetKeys records transaction keys during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1750,7 +1753,7 @@ test.concurrent("private_writeEventsAndGetKeys records transaction keys during u
 });
 
 test.concurrent("private_writeEventsAndGetKeys records withdrawal keys during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1794,7 +1797,7 @@ test.concurrent("private_writeEventsAndGetKeys records withdrawal keys during up
 });
 
 test.concurrent("private_writeEventsAndGetKeys records receipt keys during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1838,7 +1841,7 @@ test.concurrent("private_writeEventsAndGetKeys records receipt keys during upser
 });
 
 test.concurrent("private_writeEventsAndGetKeys records log keys during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1884,7 +1887,7 @@ test.concurrent("private_writeEventsAndGetKeys records log keys during upsert", 
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full block when using JSON.stringify", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -1993,7 +1996,7 @@ test.concurrent("private_writeEventsAndGetKeys records full block when using JSO
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full transactions when using JSON.stringify", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -2051,7 +2054,7 @@ test.concurrent("private_writeEventsAndGetKeys records full transactions when us
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full withdrawals when using JSON.stringify", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -2090,7 +2093,7 @@ test.concurrent("private_writeEventsAndGetKeys records full withdrawals when usi
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full receipts when using JSON.stringify", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -2150,7 +2153,7 @@ test.concurrent("private_writeEventsAndGetKeys records full receipts when using 
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full receipt logs when using JSON.stringify", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -2199,7 +2202,7 @@ test.concurrent("private_writeEventsAndGetKeys records full receipt logs when us
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full blocks during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -2314,7 +2317,7 @@ test.concurrent("private_writeEventsAndGetKeys records full blocks during upsert
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full transactions during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -2378,7 +2381,7 @@ test.concurrent("private_writeEventsAndGetKeys records full transactions during 
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full withdrawals during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -2423,7 +2426,7 @@ test.concurrent("private_writeEventsAndGetKeys records full withdrawals during u
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full receipts during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -2489,7 +2492,7 @@ test.concurrent("private_writeEventsAndGetKeys records full receipts during upse
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full receipt logs during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -2542,7 +2545,7 @@ test.concurrent("private_writeEventsAndGetKeys records full receipt logs during 
 });
 
 test.concurrent("private_writeEventsAndGetKeys returns accessed properties that are undefined", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",

--- a/packages/univo/src/index.ts
+++ b/packages/univo/src/index.ts
@@ -1,3 +1,5 @@
+import type { Storage } from "unstorage";
+
 import * as utils from "./utils";
 import type { Flatten } from "./utils";
 import { version } from "../package.json";
@@ -204,6 +206,18 @@ type IndexerOptions<TBlock> = {
 	 */
 	signingKey: string;
 	/**
+	 * Storage interface for durably persisting indexer metadata.
+	 *
+	 * This uses the unified key-value storage API from unstorage. Install the `unstorage` dependency
+	 * and provide the return value of your `createStorage()` call. Check out the documentation for
+	 * a full list of [supported storage drivers](https://unstorage.unjs.io/drivers).
+	 *
+	 * Functionally, storing metadata is fundamental to ensure the correct operation of your indexer. It
+	 * ensures that you indexer recovers from downtime, ensures that all blocks are processed correctly during
+	 * chain reorganisations, and records any errors when unable to upsert or delete events in realtime.
+	 */
+	metadataStorage: Storage;
+	/**
 	 * Loads raw block data in realtime from a trusted set of RPC sources.
 	 *
 	 * Note that historical backfills do not use this function to load block data.
@@ -296,6 +310,23 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 		},
 	};
 
+	// Metadata storage interface. Functionally this is responsible for storing all state related to ensuring
+	// the correct processing of the indexer.
+
+	const metadata = {};
+
+	/**
+	 * Fetches a block using the provided `getBlock` function. Handles retries. The block hash is optional
+	 * because we sometimes want the canonical block using only the block number. If a hash is provided we
+	 * will assert that the block returned via the block number lookup is the expected block
+	 */
+	async function getBlock(head: { chain: `0x${string}`; number: `0x${string}`; hash?: `0x${string}` }) {
+		return await utils.retry(retry_getBlock, [head], 2).catch(() => {
+			log.error("Failed to load block from the provided `getBlock` function after 3 attempts");
+			return null;
+		});
+	}
+
 	async function retry_getBlock(head: { chain: `0x${string}`; number: `0x${string}`; hash?: `0x${string}` }) {
 		const block = await opts.getBlock({ chain: head.chain, number: head.number });
 
@@ -316,18 +347,6 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 		}
 
 		return block;
-	}
-
-	/**
-	 * Fetches a block using the provided `getBlock` function. Handles retries. The block hash is optional
-	 * because we sometimes want the canonical block using only the block number. If a hash is provided we
-	 * will assert that the block returned via the block number lookup is the expected block
-	 */
-	async function getBlock(head: { chain: `0x${string}`; number: `0x${string}`; hash?: `0x${string}` }) {
-		return await utils.retry(retry_getBlock, [head], 2).catch(() => {
-			log.error("Failed to load block from the provided `getBlock` function after 3 attempts");
-			return null;
-		});
 	}
 
 	async function signCompressAndEncryptBlock(block: TBlock) {

--- a/packages/univo/src/realtime.test.ts
+++ b/packages/univo/src/realtime.test.ts
@@ -1,5 +1,6 @@
 import { http } from "msw";
 import { test } from "vitest";
+import { createStorage } from "unstorage";
 
 import { indexer } from ".";
 import { server } from "../vitest.setup";
@@ -9,7 +10,7 @@ import { test_getBlock, test_promiseWithResolvers, test_indexer } from "../tests
 test("receives a block", async () => {
 	const { promise, resolve } = test_promiseWithResolvers();
 
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	univo.event({
 		id: "test",
@@ -41,7 +42,7 @@ test("receives a block", async () => {
 test("retries blocks", async () => {
 	const { promise, resolve } = test_promiseWithResolvers();
 
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock });
+	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	let count = 0;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       partysocket:
         specifier: ^1.1.3
         version: 1.1.3
+      unstorage:
+        specifier: '>=1'
+        version: 1.17.5
       ws:
         specifier: ^8.18.1
         version: 8.18.1
@@ -750,6 +753,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -813,6 +820,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
@@ -854,9 +865,15 @@ packages:
   convert-gitmoji@0.1.5:
     resolution: {integrity: sha512-4wqOafJdk2tqZC++cjcbGcaJ13BZ3kwldf06PTiAQRAB76Z1KJwZNL1SaRZMi2w1FM9RYTgZ6QErS8NUl/GBmQ==}
 
+  cookie-es@1.2.3:
+    resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  crossws@0.3.5:
+    resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
   css-declaration-sorter@7.2.0:
     resolution: {integrity: sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==}
@@ -937,6 +954,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -1042,6 +1062,9 @@ packages:
     resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  h3@1.15.11:
+    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
   has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
@@ -1055,6 +1078,9 @@ packages:
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  iron-webcrypto@1.2.1:
+    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
   is-core-module@2.11.0:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
@@ -1118,6 +1144,10 @@ packages:
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -1180,8 +1210,18 @@ packages:
   node-fetch-native@1.6.6:
     resolution: {integrity: sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==}
 
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-mock-http@1.0.4:
+    resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
@@ -1197,6 +1237,9 @@ packages:
 
   ofetch@1.4.1:
     resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
+
+  ofetch@1.5.1:
+    resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
@@ -1237,6 +1280,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
@@ -1441,12 +1488,19 @@ packages:
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
+  radix3@1.1.2:
+    resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -1576,6 +1630,9 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   unbuild@3.5.0:
     resolution: {integrity: sha512-DPFttsiADnHRb/K+yJ9r9jdn6JyXlsmdT0S12VFC14DFSJD+cxBnHq+v0INmqqPVPxOoUjvJFYUVIb02rWnVeA==}
     hasBin: true
@@ -1584,6 +1641,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -1595,6 +1655,68 @@ packages:
   univo@0.1.13:
     resolution: {integrity: sha512-xy6luj5Rfni+Qp7Sn7FMkrw+XQUuTQaieIcxHglo+RvZwHokwzTDpQMdOPiDZcjcCBzOn0GUyBCHFI1f688uAQ==}
     hasBin: true
+
+  unstorage@1.17.5:
+    resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1 || ^2 || ^3
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
+        optional: true
 
   untyped@2.0.0:
     resolution: {integrity: sha512-nwNCjxJTjNuLCgFr42fEak5OcLuB3ecca+9ksPFNvtfYSLpjf+iJqSIaSnIile6ZPbKYxI5k2AfXqeopGudK/g==}
@@ -2202,6 +2324,11 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
   assertion-error@2.0.1: {}
 
   autoprefixer@10.4.21(postcss@8.5.3):
@@ -2291,6 +2418,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
@@ -2323,7 +2454,13 @@ snapshots:
 
   convert-gitmoji@0.1.5: {}
 
+  cookie-es@1.2.3: {}
+
   cookie@0.7.2: {}
+
+  crossws@0.3.5:
+    dependencies:
+      uncrypto: 0.1.3
 
   css-declaration-sorter@7.2.0(postcss@8.5.3):
     dependencies:
@@ -2417,6 +2554,8 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.4: {}
+
+  defu@6.1.7: {}
 
   destr@2.0.5: {}
 
@@ -2549,6 +2688,18 @@ snapshots:
 
   graphql@16.11.0: {}
 
+  h3@1.15.11:
+    dependencies:
+      cookie-es: 1.2.3
+      crossws: 0.3.5
+      defu: 6.1.7
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.4
+      radix3: 1.1.2
+      ufo: 1.6.4
+      uncrypto: 0.1.3
+
   has@1.0.3:
     dependencies:
       function-bind: 1.1.1
@@ -2558,6 +2709,8 @@ snapshots:
   hono@4.7.8: {}
 
   hookable@5.5.3: {}
+
+  iron-webcrypto@1.2.1: {}
 
   is-core-module@2.11.0:
     dependencies:
@@ -2603,6 +2756,8 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   loupe@3.1.3: {}
+
+  lru-cache@11.3.6: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -2672,7 +2827,13 @@ snapshots:
 
   node-fetch-native@1.6.6: {}
 
+  node-fetch-native@1.6.7: {}
+
+  node-mock-http@1.0.4: {}
+
   node-releases@2.0.19: {}
+
+  normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
 
@@ -2693,6 +2854,12 @@ snapshots:
       destr: 2.0.5
       node-fetch-native: 1.6.6
       ufo: 1.6.1
+
+  ofetch@1.5.1:
+    dependencies:
+      destr: 2.0.5
+      node-fetch-native: 1.6.7
+      ufo: 1.6.4
 
   ohash@2.0.11: {}
 
@@ -2735,6 +2902,8 @@ snapshots:
   perfect-debounce@1.0.0: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.2: {}
 
@@ -2927,12 +3096,16 @@ snapshots:
 
   querystringify@2.2.0: {}
 
+  radix3@1.1.2: {}
+
   rc9@2.1.2:
     dependencies:
       defu: 6.1.4
       destr: 2.0.5
 
   readdirp@4.1.2: {}
+
+  readdirp@5.0.0: {}
 
   require-directory@2.1.1: {}
 
@@ -3058,6 +3231,8 @@ snapshots:
 
   ufo@1.6.1: {}
 
+  ufo@1.6.4: {}
+
   unbuild@3.5.0(typescript@5.8.2):
     dependencies:
       '@rollup/plugin-alias': 5.1.1(rollup@4.40.2)
@@ -3092,6 +3267,8 @@ snapshots:
       - vue-sfc-transformer
       - vue-tsc
 
+  uncrypto@0.1.3: {}
+
   undici-types@5.26.5: {}
 
   universalify@0.2.0: {}
@@ -3106,6 +3283,17 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  unstorage@1.17.5:
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.3.6
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
 
   untyped@2.0.0:
     dependencies:


### PR DESCRIPTION
This is a breaking API change that serves as the foundation for a lot of future improvements. 

This PR doesn't include any new features rather it just updates the API and overall architecture of the indexer to include a metadata storage layer. For years I have debated whether something like this was necessary to add to the API and have finally decided it's worth it.

Fundamentally we need to store metadata to enforce correctness. Up until this point correctness was tied to the availability of several systems, in general this is bad system design as liveness issues should never bleed into correctness issues. This metadata layer serves as the foundation to build an always-correct indexing system. I will talk about how this metadata will be used specifically in future improvements.

In terms of the storage interface, I settled on `unstorage` which is well-supported KV storage API by the folks at [unjs](https://github.com/unjs). They build beautiful, foundational software in the Typescript ecosystem so I feel comfortable adding them as the first dependency. A KV API is simple to implement and manage and prevents a lot of complexity. They support multiple storage drivers so users should be easily able to plug in their existing storage systems.