### PR TITLE
feat(transport): Add `local` transport for RPC

### DIFF
--- a/packages/univo/package.json
+++ b/packages/univo/package.json
@@ -43,11 +43,9 @@
 		"ws": "^8.18.1"
 	},
 	"devDependencies": {
-		"@hono/node-server": "^1.14.1",
 		"@types/node": "^20.11.27",
 		"@types/ws": "^8.18.1",
 		"changelogen": "^0.6.1",
-		"hono": "^4.7.8",
 		"jiti": "^2.4.2",
 		"msw": "^2.10.2",
 		"typescript": "^5.8.2",

--- a/packages/univo/src/index.test.ts
+++ b/packages/univo/src/index.test.ts
@@ -3,8 +3,9 @@ import { createStorage } from "unstorage";
 
 import { indexer } from ".";
 import type { Event } from ".";
+import { local } from "./transport";
 import { hexToNumber, numberToHex } from "./utils";
-import { test_Block, test_getBlock, test_indexer } from "../tests/utils";
+import { test_Block, test_getBlock } from "../tests/utils";
 
 test.concurrent("correctly infers the event type", () => {
 	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
@@ -68,7 +69,7 @@ test.concurrent("public_writeUnfinalizedHeads upserts events", async () => {
 		filters: [{ chain: 1, fromBlock: 0 }],
 	});
 
-	await test_indexer(univo).request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -118,7 +119,7 @@ test.concurrent("public_writeUnfinalizedHeads retries upsert errors", async () =
 		},
 	});
 
-	await test_indexer(univo).request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -176,7 +177,7 @@ test.concurrent("public_writeUnfinalizedHeads deduplicates events with the same 
 		handler: (block) => [`event2-${block.eth_getBlockByNumber.hash}`],
 	});
 
-	await test_indexer(univo).request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -233,7 +234,7 @@ test.concurrent("public_writeUnfinalizedHeads tolerates partial block-load failu
 		},
 	});
 
-	await test_indexer(univo).request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -289,7 +290,7 @@ test.concurrent("public_writeUnfinalizedHeads ignores finalized heads", async ()
 		},
 	});
 
-	await test_indexer(univo).request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -355,9 +356,7 @@ test.concurrent("public_deleteReorganisedHead deletes events from reorganised bl
 		},
 	});
 
-	const client = test_indexer(univo);
-
-	await client.request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -371,7 +370,7 @@ test.concurrent("public_deleteReorganisedHead deletes events from reorganised bl
 		],
 	});
 
-	await client.request({
+	await local(univo).request({
 		method: "public_deleteReorganisedHead",
 		params: [
 			{
@@ -408,7 +407,7 @@ test.concurrent("public_deleteReorganisedHead never deletes events from canonica
 		},
 	});
 
-	await test_indexer(univo).request({
+	await local(univo).request({
 		method: "public_deleteReorganisedHead",
 		params: [
 			{
@@ -466,9 +465,7 @@ test.concurrent("public_writeFinalizedHeads writes finalized heads", async () =>
 		},
 	});
 
-	const client = test_indexer(univo);
-
-	await client.request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -482,7 +479,7 @@ test.concurrent("public_writeFinalizedHeads writes finalized heads", async () =>
 		],
 	});
 
-	await client.request({
+	await local(univo).request({
 		method: "public_writeFinalizedHeads",
 		params: [
 			[
@@ -565,9 +562,7 @@ test.concurrent("public_writeFinalizedHeads removes reorganised events", async (
 		},
 	});
 
-	const client = test_indexer(univo);
-
-	await client.request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -581,7 +576,7 @@ test.concurrent("public_writeFinalizedHeads removes reorganised events", async (
 		],
 	});
 
-	await client.request({
+	await local(univo).request({
 		method: "public_writeFinalizedHeads",
 		params: [
 			[
@@ -603,7 +598,7 @@ test.concurrent("public_writeFinalizedHeads throws when receiving heads from dif
 	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
 
 	await expect(
-		test_indexer(univo).request({
+		local(univo).request({
 			method: "public_writeFinalizedHeads",
 			params: [
 				[
@@ -642,9 +637,7 @@ test.concurrent("public_writeFinalizedHeads throws when receiving an unknown hea
 		},
 	});
 
-	const client = test_indexer(univo);
-
-	await client.request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -659,7 +652,7 @@ test.concurrent("public_writeFinalizedHeads throws when receiving an unknown hea
 	});
 
 	await expect(
-		client.request({
+		local(univo).request({
 			method: "public_writeFinalizedHeads",
 			params: [
 				[
@@ -696,7 +689,7 @@ test.concurrent("public_writeFinalizedHeads throws if it receives a head greater
 	});
 
 	await expect(
-		test_indexer(univo).request({
+		local(univo).request({
 			method: "public_writeFinalizedHeads",
 			params: [
 				[
@@ -751,9 +744,7 @@ test.concurrent("public_writeFinalizedHeads deletes finalized metadata blocks af
 		storage: { upsert: async () => {} },
 	});
 
-	const client = test_indexer(univo);
-
-	await client.request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -769,7 +760,7 @@ test.concurrent("public_writeFinalizedHeads deletes finalized metadata blocks af
 
 	expect(await metadataStorage.getKeys("/blocks/v1/0x1")).not.toStrictEqual([]);
 
-	await client.request({
+	await local(univo).request({
 		method: "public_writeFinalizedHeads",
 		params: [
 			[
@@ -803,9 +794,7 @@ test.concurrent("public_writeFinalizedHeads rejects wrong parent linkage between
 		},
 	});
 
-	const client = test_indexer(univo);
-
-	await client.request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -826,7 +815,7 @@ test.concurrent("public_writeFinalizedHeads rejects wrong parent linkage between
 	});
 
 	await expect(
-		client.request({
+		local(univo).request({
 			method: "public_writeFinalizedHeads",
 			params: [
 				[
@@ -893,9 +882,7 @@ test.concurrent("public_writeFinalizedHeads is idempotent when called twice with
 		},
 	});
 
-	const client = test_indexer(univo);
-
-	await client.request({
+	await local(univo).request({
 		method: "public_writeUnfinalizedHeads",
 		params: [
 			[
@@ -909,7 +896,7 @@ test.concurrent("public_writeFinalizedHeads is idempotent when called twice with
 		],
 	});
 
-	await client.request({
+	await local(univo).request({
 		method: "public_writeFinalizedHeads",
 		params: [
 			[
@@ -923,7 +910,7 @@ test.concurrent("public_writeFinalizedHeads is idempotent when called twice with
 		],
 	});
 
-	await client.request({
+	await local(univo).request({
 		method: "public_writeFinalizedHeads",
 		params: [
 			[
@@ -969,7 +956,7 @@ test.concurrent("private_writeEvents indexes only the events requested", async (
 
 	const block0 = await test_getBlock({ chain: "0x1", number: numberToHex(0) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1013,7 +1000,7 @@ test.concurrent("private_writeEvents deduplicates events with the same storage a
 
 	const block0 = await test_getBlock({ chain: "0x1", number: numberToHex(0) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1042,7 +1029,7 @@ test.concurrent("private_writeEvents records events", async () => {
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1075,7 +1062,7 @@ test.concurrent("private_writeEvents ignores events not explicitly requested", a
 	const block1 = await test_getBlock({ chain: "0x1", number: numberToHex(1) });
 	const block2 = await test_getBlock({ chain: "0x1", number: numberToHex(2) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1108,7 +1095,7 @@ test.concurrent("private_writeEvents returns handler errors", async () => {
 	const block1 = await test_getBlock({ chain: "0x1", number: numberToHex(1) });
 	const block2 = await test_getBlock({ chain: "0x1", number: numberToHex(2) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1148,7 +1135,7 @@ test.concurrent("private_writeEvents returns errors thrown during upsert", async
 	const block1 = await test_getBlock({ chain: "0x1", number: numberToHex(1) });
 	const block2 = await test_getBlock({ chain: "0x1", number: numberToHex(2) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1207,7 +1194,7 @@ test.concurrent("private_writeEvents retries upsert errors", async () => {
 	const block1 = await test_getBlock({ chain: "0x1", number: numberToHex(1) });
 	const block2 = await test_getBlock({ chain: "0x1", number: numberToHex(2) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1267,7 +1254,7 @@ test.concurrent("private_writeEvents only returns the handler error if both hand
 	const block1 = await test_getBlock({ chain: "0x1", number: numberToHex(1) });
 	const block2 = await test_getBlock({ chain: "0x1", number: numberToHex(2) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1318,7 +1305,7 @@ test.concurrent("private_writeEvents returns incomplete errors in handler", asyn
 		storage: { upsert: async () => {} },
 	});
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1382,7 +1369,7 @@ test.concurrent("private_writeEvents returns swallowed incomplete errors in hand
 		storage: { upsert: async () => {} },
 	});
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1444,7 +1431,7 @@ test.concurrent("private_writeEvents returns incomplete errors in upsert", async
 		},
 	});
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1509,7 +1496,7 @@ test.concurrent("private_writeEvents returns swallowed incomplete errors in upse
 		},
 	});
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1564,7 +1551,7 @@ test.concurrent("private_writeEvents doesn't return an error when accessing a pr
 		handler: (block) => [block.eth_getBlockByNumber.difficulty],
 	});
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1612,7 +1599,7 @@ test.concurrent("private_writeEvents never upserts if handler returns empty even
 	const block1 = await test_getBlock({ chain: "0x1", number: numberToHex(1) });
 	const block2 = await test_getBlock({ chain: "0x1", number: numberToHex(2) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEvents",
 		params: [
 			{
@@ -1654,7 +1641,7 @@ test.concurrent("private_writeEventsAndGetKeys indexes only the events requested
 
 	const block0 = await test_getBlock({ chain: "0x1", number: numberToHex(0) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["event1"], block: block0 }],
 	});
@@ -1690,7 +1677,7 @@ test.concurrent("private_writeEventsAndGetKeys never upserts if handler returns 
 
 	const block0 = await test_getBlock({ chain: "0x1", number: numberToHex(0) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block0 }],
 	});
@@ -1719,7 +1706,7 @@ test.concurrent("private_writeEventsAndGetKeys records minimum keys from matchin
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -1754,7 +1741,7 @@ test.concurrent("private_writeEventsAndGetKeys records block keys during handler
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -1794,7 +1781,7 @@ test.concurrent("private_writeEventsAndGetKeys records transaction keys during h
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -1834,7 +1821,7 @@ test.concurrent("private_writeEventsAndGetKeys records withdrawals keys during h
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -1874,7 +1861,7 @@ test.concurrent("private_writeEventsAndGetKeys records receipt keys during handl
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -1916,7 +1903,7 @@ test.concurrent("private_writeEventsAndGetKeys records log keys during handler",
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -1958,7 +1945,7 @@ test.concurrent("private_writeEventsAndGetKeys records block keys during upsert"
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2001,7 +1988,7 @@ test.concurrent("private_writeEventsAndGetKeys records transaction keys during u
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2045,7 +2032,7 @@ test.concurrent("private_writeEventsAndGetKeys records withdrawal keys during up
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2089,7 +2076,7 @@ test.concurrent("private_writeEventsAndGetKeys records receipt keys during upser
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2135,7 +2122,7 @@ test.concurrent("private_writeEventsAndGetKeys records log keys during upsert", 
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2171,7 +2158,7 @@ test.concurrent("private_writeEventsAndGetKeys records full block when using JSO
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2280,7 +2267,7 @@ test.concurrent("private_writeEventsAndGetKeys records full transactions when us
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2338,7 +2325,7 @@ test.concurrent("private_writeEventsAndGetKeys records full withdrawals when usi
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2377,7 +2364,7 @@ test.concurrent("private_writeEventsAndGetKeys records full receipts when using 
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2441,7 +2428,7 @@ test.concurrent("private_writeEventsAndGetKeys records full receipt logs when us
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2492,7 +2479,7 @@ test.concurrent("private_writeEventsAndGetKeys records full blocks during upsert
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2607,7 +2594,7 @@ test.concurrent("private_writeEventsAndGetKeys records full transactions during 
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2671,7 +2658,7 @@ test.concurrent("private_writeEventsAndGetKeys records full withdrawals during u
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2716,7 +2703,7 @@ test.concurrent("private_writeEventsAndGetKeys records full receipts during upse
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2784,7 +2771,7 @@ test.concurrent("private_writeEventsAndGetKeys records full receipt logs during 
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});
@@ -2836,7 +2823,7 @@ test.concurrent("private_writeEventsAndGetKeys returns accessed properties that 
 
 	const block22994233 = await test_getBlock({ chain: "0x1", number: numberToHex(22994233) });
 
-	const response = await test_indexer(univo).request({
+	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
 		params: [{ events: ["test"], block: block22994233 }],
 	});

--- a/packages/univo/src/index.ts
+++ b/packages/univo/src/index.ts
@@ -1,5 +1,6 @@
 import type { Storage } from "unstorage";
 
+import { local } from "./transport";
 import type { IndexerRpc } from "./rpc";
 import { version } from "../package.json";
 import { catchException, createException, getException } from "./exceptions";
@@ -1209,35 +1210,23 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 		return { results: results_array, keys: filtered_keys };
 	};
 
-	const rpc: IndexerRpc["request"] = {
-		public_getFinalizedHeight,
-		public_writeFinalizedHeads,
-		public_writeUnfinalizedHeads,
-		public_deleteReorganisedHead,
+	const rpc: IndexerRpc = {
+		request: {
+			public_getFinalizedHeight,
+			public_writeFinalizedHeads,
+			public_writeUnfinalizedHeads,
+			public_deleteReorganisedHead,
 
-		private_getEvents,
-		private_getMetadata,
-		private_writeEvents,
-		private_writeEventsAndGetKeys,
+			private_getEvents,
+			private_getMetadata,
+			private_writeEvents,
+			private_writeEventsAndGetKeys,
+		},
+
+		subscribe: {},
 	};
 
-	// Indexer implementation
-
-	const event: Indexer<TBlock>["event"] = (event) => {
-		if (!/^[A-Za-z0-9_-]+$/.test(event.id)) {
-			throw new Error(`Invalid event id \`${event.id}\`. Only characters A-Z, a-z, 0-9, underscores, and hyphens are permitted.`);
-		}
-
-		all_events.push(event);
-
-		const group = events_grouped_by_storage_map.get(event.storage) ?? [];
-		group.push(event);
-		events_grouped_by_storage_map.set(event.storage, group);
-
-		return event;
-	};
-
-	const UnknownMethodError = createException("The requested method does not exist");
+	const transport = local(rpc);
 
 	const handler: Indexer<TBlock>["fetch"] = async (req) => {
 		// Parse request body
@@ -1313,10 +1302,7 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 
 		// Perform RPC
 		try {
-			if (rpc[json.method as keyof IndexerRpc["request"]] === undefined) throw new Error(UnknownMethodError);
-
-			// @ts-expect-error types too complicated
-			const result = await rpc[json.method](...json.params);
+			const result = await transport.request({ method: json.method, params: json.params });
 
 			return Response.json({ jsonrpc: "2.0", id: json.id, result });
 		} catch (error) {
@@ -1343,7 +1329,27 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 		}
 	};
 
-	return { fetch: handler, event };
+	const event: Indexer<TBlock>["event"] = (event) => {
+		if (!/^[A-Za-z0-9_-]+$/.test(event.id)) {
+			throw new Error(`Invalid event id \`${event.id}\`. Only characters A-Z, a-z, 0-9, underscores, and hyphens are permitted.`);
+		}
+
+		all_events.push(event);
+
+		const group = events_grouped_by_storage_map.get(event.storage) ?? [];
+		group.push(event);
+		events_grouped_by_storage_map.set(event.storage, group);
+
+		return event;
+	};
+
+	const indexer = {
+		...rpc,
+		event,
+		fetch: handler,
+	};
+
+	return indexer;
 }
 
 /**

--- a/packages/univo/src/transport.ts
+++ b/packages/univo/src/transport.ts
@@ -6,7 +6,7 @@ import type { Rpc } from "./rpc";
 import { createException } from "./exceptions";
 import { compress, createLogger, raise } from "./utils";
 
-type Protocol = "http" | "wss";
+type Protocol = "http" | "wss" | "local";
 
 type Transport<R extends Rpc, P extends Protocol = Protocol> = {
 	/**
@@ -15,7 +15,7 @@ type Transport<R extends Rpc, P extends Protocol = Protocol> = {
 	protocol: P;
 
 	/**
-	 * Performs a JSON RPC request
+	 * Performs an RPC request
 	 * @returns The RPC response
 	 */
 	request: <M extends keyof R["request"]>(opts: {
@@ -29,6 +29,30 @@ type Transport<R extends Rpc, P extends Protocol = Protocol> = {
 	 */
 	subscribe: <M extends keyof R["subscribe"]>(param: M, handler: (message: R["subscribe"][M]) => void) => Promise<() => Promise<void>>;
 };
+
+/**
+ * LOCAL -----------------------------------------------------------------------------------------------------------------------------------
+ */
+
+const UnknownMethodError = createException("The requested RPC method does not exist on the provided implementation");
+
+function local<R extends Rpc>(rpc: R): Transport<R, "local"> {
+	const request: Transport<Rpc>["request"] = async (opts) => {
+		const method = rpc.request[opts.method];
+
+		if (method === undefined) {
+			throw new Error(UnknownMethodError);
+		}
+
+		return await method(...opts.params);
+	};
+
+	const subscribe: Transport<Rpc>["subscribe"] = async () => {
+		throw new Error("Unable to `subscribe` on `local` transport");
+	};
+
+	return { protocol: "local", request, subscribe };
+}
 
 /**
  * WSS -----------------------------------------------------------------------------------------------------------------------------------
@@ -324,5 +348,5 @@ const ClientUnauthorizedError = createException("Attempted to execute a private 
  * Exports -----------------------------------------------------------------------------------------------------------------------------------
  */
 
-export { http, wss };
 export type { Transport };
+export { http, local, wss };

--- a/packages/univo/tests/utils.ts
+++ b/packages/univo/tests/utils.ts
@@ -1,38 +1,8 @@
-import { Hono } from "hono";
 import { join } from "node:path";
 import { promises as fs } from "node:fs";
-import { serve as start } from "@hono/node-server";
 import type { RpcBlock, RpcTransactionReceipt } from "viem";
 
-import type { Indexer } from "../src";
-import { http } from "../src/transport";
-import { IndexerRpc } from "../src/rpc";
-import { hexToNumber, iife, raise, retry } from "../src/utils";
-
-export const test_indexer = iife(() => {
-	const app = new Hono();
-	const cache = new Map<string, Indexer<any>>();
-
-	app.all("/:key", async (context) => {
-		const key = context.req.param("key");
-		const indexer = cache.get(key);
-		if (indexer === undefined) throw new Error("Unknown indexer");
-		return await indexer.fetch(context.req.raw);
-	});
-
-	start({ fetch: app.fetch, port: 7483 });
-
-	return <TBlock>(indexer: Indexer<TBlock>) => {
-		const id = crypto.randomUUID();
-		const url = `http://localhost:7483/${id}`;
-		cache.set(id, indexer);
-
-		// Signing key should be "test" for all test indexers
-		const { request } = http<IndexerRpc>(url, { signingKey: "test" });
-
-		return { url, request };
-	};
-});
+import { hexToNumber, retry } from "../src/utils";
 
 export function test_promiseWithResolvers() {
 	let resolve: (value: any) => void;
@@ -100,7 +70,10 @@ export async function test_getBlock(block: { chain: `0x${string}`; number: strin
 
 async function rpc(opts: { id: number; method: string; params: any[] }) {
 	const url = process.env.TEST_ETHEREUM_RPC_URL;
-	if (!url) throw new Error("Please set a process.env.TEST_ETHEREUM_RPC_URL");
+
+	if (!url) {
+		throw new Error("Please set a process.env.TEST_ETHEREUM_RPC_URL");
+	}
 
 	const res = await fetch(url, {
 		method: "POST",
@@ -108,8 +81,13 @@ async function rpc(opts: { id: number; method: string; params: any[] }) {
 		body: JSON.stringify({ jsonrpc: "2.0", ...opts }),
 	});
 
-	if (!res.ok) throw new Error("Failed to get rpc response");
-	const json: any = await res.json().catch((cause) => raise("Unable to parse rpc response to json", { cause }));
+	if (!res.ok) {
+		throw new Error("Failed to get rpc response");
+	}
+
+	const json: any = await res.json().catch((cause) => {
+		throw new Error("Unable to parse rpc response to json", { cause });
+	});
 
 	return json.result;
 }

--- a/packages/univo/vitest.setup.ts
+++ b/packages/univo/vitest.setup.ts
@@ -6,10 +6,6 @@ import { http, passthrough } from "msw";
 
 config({ quiet: true });
 
-if (process.env.TEST_ETHEREUM_RPC_WSS === undefined) {
-	throw new Error("Set a TEST_ETHEREUM_RPC_WSS environment variable");
-}
-
 if (process.env.TEST_ETHEREUM_RPC_URL === undefined) {
 	throw new Error("Set a TEST_ETHEREUM_RPC_URL environment variable");
 }
@@ -17,7 +13,6 @@ if (process.env.TEST_ETHEREUM_RPC_URL === undefined) {
 declare global {
 	namespace NodeJS {
 		interface ProcessEnv {
-			TEST_ETHEREUM_RPC_WSS: string;
 			TEST_ETHEREUM_RPC_URL: string;
 		}
 	}
@@ -26,8 +21,7 @@ declare global {
 // Mock service worker
 
 export const server = setupServer(
-	http.all("http://localhost:7483/:key", passthrough),
-	http.all(process.env.TEST_ETHEREUM_RPC_URL, passthrough),
+	http.all(process.env.TEST_ETHEREUM_RPC_URL, passthrough), //
 );
 
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,9 +46,6 @@ importers:
         specifier: ^8.18.1
         version: 8.18.1
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.14.1
-        version: 1.14.1(hono@4.7.8)
       '@types/node':
         specifier: ^20.11.27
         version: 20.11.27
@@ -58,9 +55,6 @@ importers:
       changelogen:
         specifier: ^0.6.1
         version: 0.6.1
-      hono:
-        specifier: ^4.7.8
-        version: 4.7.8
       jiti:
         specifier: ^2.4.2
         version: 2.4.2
@@ -436,12 +430,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@hono/node-server@1.14.1':
-    resolution: {integrity: sha512-vmbuM+HPinjWzPe7FFPWMMQMsbKE9gDPhaH0FFdqbGpkT5lp++tcWDTxwBl5EgS5y6JVgIaCdjeHRfQ4XRBRjQ==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
 
   '@inquirer/confirm@5.1.13':
     resolution: {integrity: sha512-EkCtvp67ICIVVzjsquUiVSd+V5HRGOGQfsqA4E4vMWhYnB7InUL0pa0TIWt1i+OfP16Gkds8CdIu6yGZwOM1Yw==}
@@ -1071,10 +1059,6 @@ packages:
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
-
-  hono@4.7.8:
-    resolution: {integrity: sha512-PCibtFdxa7/Ldud9yddl1G81GjYaeMYYTq4ywSaNsYbB1Lug4mwtOMJf2WXykL0pntYwmpRJeOI3NmoDgD+Jxw==}
-    engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -2063,10 +2047,6 @@ snapshots:
   '@esbuild/win32-x64@0.25.4':
     optional: true
 
-  '@hono/node-server@1.14.1(hono@4.7.8)':
-    dependencies:
-      hono: 4.7.8
-
   '@inquirer/confirm@5.1.13(@types/node@20.11.27)':
     dependencies:
       '@inquirer/core': 10.1.14(@types/node@20.11.27)
@@ -2705,8 +2685,6 @@ snapshots:
       function-bind: 1.1.1
 
   headers-polyfill@4.0.3: {}
-
-  hono@4.7.8: {}
 
   hookable@5.5.3: {}
 


### PR DESCRIPTION
Adds support for a `local` transport method.

This lays the groundwork for an improvement later where the indexer and realtime client can be colocated inside the same environment. At the moment we encourage a stateless design for the indexer so these should be separated for now. But with planned improvements in future this will be important. Also simplifies our testing.