### PR TITLE
feat(keys): Use provided RPC methods for `public_writeEventsAndGetKeys`

### DIFF
--- a/packages/univo/src/index.test.ts
+++ b/packages/univo/src/index.test.ts
@@ -1643,7 +1643,17 @@ test.concurrent("private_writeEventsAndGetKeys indexes only the events requested
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["event1"], block: block0 }],
+		params: [
+			{
+				events: ["event1"],
+				head: {
+					chain: "0x1",
+					hash: block0.eth_getBlockByNumber.hash,
+					number: block0.eth_getBlockByNumber.number,
+					parentHash: block0.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -1679,7 +1689,17 @@ test.concurrent("private_writeEventsAndGetKeys never upserts if handler returns 
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block0 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block0.eth_getBlockByNumber.hash,
+					number: block0.eth_getBlockByNumber.number,
+					parentHash: block0.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -1708,7 +1728,17 @@ test.concurrent("private_writeEventsAndGetKeys records minimum keys from matchin
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -1743,7 +1773,17 @@ test.concurrent("private_writeEventsAndGetKeys records block keys during handler
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -1783,7 +1823,17 @@ test.concurrent("private_writeEventsAndGetKeys records transaction keys during h
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -1823,7 +1873,17 @@ test.concurrent("private_writeEventsAndGetKeys records withdrawals keys during h
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -1863,7 +1923,17 @@ test.concurrent("private_writeEventsAndGetKeys records receipt keys during handl
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -1905,7 +1975,17 @@ test.concurrent("private_writeEventsAndGetKeys records log keys during handler",
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -1947,7 +2027,17 @@ test.concurrent("private_writeEventsAndGetKeys records block keys during upsert"
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -1990,7 +2080,17 @@ test.concurrent("private_writeEventsAndGetKeys records transaction keys during u
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2034,7 +2134,17 @@ test.concurrent("private_writeEventsAndGetKeys records withdrawal keys during up
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2078,7 +2188,17 @@ test.concurrent("private_writeEventsAndGetKeys records receipt keys during upser
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2124,7 +2244,17 @@ test.concurrent("private_writeEventsAndGetKeys records log keys during upsert", 
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2160,7 +2290,17 @@ test.concurrent("private_writeEventsAndGetKeys records full block when using JSO
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2269,7 +2409,17 @@ test.concurrent("private_writeEventsAndGetKeys records full transactions when us
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2327,7 +2477,17 @@ test.concurrent("private_writeEventsAndGetKeys records full withdrawals when usi
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2366,7 +2526,17 @@ test.concurrent("private_writeEventsAndGetKeys records full receipts when using 
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2430,7 +2600,17 @@ test.concurrent("private_writeEventsAndGetKeys records full receipt logs when us
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2481,7 +2661,17 @@ test.concurrent("private_writeEventsAndGetKeys records full blocks during upsert
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2596,7 +2786,17 @@ test.concurrent("private_writeEventsAndGetKeys records full transactions during 
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2660,7 +2860,17 @@ test.concurrent("private_writeEventsAndGetKeys records full withdrawals during u
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2705,7 +2915,17 @@ test.concurrent("private_writeEventsAndGetKeys records full receipts during upse
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2773,7 +2993,17 @@ test.concurrent("private_writeEventsAndGetKeys records full receipt logs during 
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([
@@ -2825,7 +3055,17 @@ test.concurrent("private_writeEventsAndGetKeys returns accessed properties that 
 
 	const response = await local(univo).request({
 		method: "private_writeEventsAndGetKeys",
-		params: [{ events: ["test"], block: block22994233 }],
+		params: [
+			{
+				events: ["test"],
+				head: {
+					chain: "0x1",
+					hash: block22994233.eth_getBlockByNumber.hash,
+					number: block22994233.eth_getBlockByNumber.number,
+					parentHash: block22994233.eth_getBlockByNumber.parentHash,
+				},
+			},
+		],
 	});
 
 	expect(response.results).toStrictEqual([

--- a/packages/univo/src/index.ts
+++ b/packages/univo/src/index.ts
@@ -1070,11 +1070,27 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 	};
 
 	const private_writeEventsAndGetKeys: IndexerRpc["request"]["private_writeEventsAndGetKeys"] = async (params) => {
-		if (all_events.length === 0) return { results: [], keys: [] };
-		if (params.events.length === 0) return { results: [], keys: [] };
+		if (all_events.length === 0) {
+			return { results: [], keys: [] };
+		}
 
+		if (params.events.length === 0) {
+			return { results: [], keys: [] };
+		}
+
+		// Filter for relevant events
 		const relevant_events = all_events.filter((event) => params.events.includes(event.id));
-		if (relevant_events.length === 0) return { results: [], keys: [] };
+
+		if (relevant_events.length === 0) {
+			return { results: [], keys: [] };
+		}
+
+		// Load the requested block
+		const block = await getBlock(params.head);
+
+		if (block === null) {
+			throw new Error(GetBlockError);
+		}
 
 		const keys = new Set<string>();
 		const results: Record<string, Result> = {};
@@ -1104,7 +1120,7 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 			};
 		}
 
-		const proxy = new Proxy(params.block, createProxyHandler("")) as Block;
+		const proxy = new Proxy(block, createProxyHandler("")) as Block;
 
 		await Promise.all(
 			relevant_events.map(async (event) => {

--- a/packages/univo/src/rpc.ts
+++ b/packages/univo/src/rpc.ts
@@ -92,10 +92,10 @@ type IndexerRpc = {
 		private_writeEvents: (params: { events: string[]; blocks: Block[] }) => Promise<{ failures: Result[] }>;
 
 		/**
-		 * Accepts a raw block directly from the chain and writes events to storage
-		 * @returns A list of the block keys that were accessed as events are written to storage
+		 * Accepts a block head and writes events to storage
+		 * @returns A list of results and block keys that were accessed as those events are written to storage
 		 */
-		private_writeEventsAndGetKeys: (params: { events: string[]; block: Block }) => Promise<{ results: Result[]; keys: string[] }>;
+		private_writeEventsAndGetKeys: (params: { events: string[]; head: Head }) => Promise<{ results: Result[]; keys: string[] }>;
 	};
 
 	subscribe: Record<string, never>;

--- a/packages/univo/src/rpc.ts
+++ b/packages/univo/src/rpc.ts
@@ -93,7 +93,7 @@ type IndexerRpc = {
 
 		/**
 		 * Accepts a block head and writes events to storage
-		 * @returns A list of results and block keys that were accessed as those events are written to storage
+		 * @returns A list of results and block keys that were accessed as those events were written to storage
 		 */
 		private_writeEventsAndGetKeys: (params: { events: string[]; head: Head }) => Promise<{ results: Result[]; keys: string[] }>;
 	};


### PR DESCRIPTION
Previously, the full block data had to be provided to `public_writeEventsAndGetKeys`.

Now, we simply provide a block head (chain, number, hash, parent hash) and load the block manually with the users provided `getBlock` function. In hindsight, it was stupid to not be doing it like this. An outside system would never be able to guess the full extent of RPC methods used by the indexer.