### PR TITLE
feat(storage): Migrate metadata storage adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ build
 playground
 *.sqlite
 .npmrc
+.storage

--- a/packages/univo/package.json
+++ b/packages/univo/package.json
@@ -54,6 +54,7 @@
 		"vitest": "^3.1.3"
 	},
 	"peerDependencies": {
-		"unstorage": ">=1"
+		"@storagesdk/core": ">=0.4.2",
+		"@storagesdk/adapters": ">=0.6.0"
 	}
 }

--- a/packages/univo/src/index.test.ts
+++ b/packages/univo/src/index.test.ts
@@ -1,14 +1,18 @@
 import { expect, test } from "vitest";
-import { createStorage } from "unstorage";
 
 import { indexer } from ".";
 import type { Event } from ".";
 import { local } from "./transport";
 import { hexToNumber, numberToHex } from "./utils";
-import { test_Block, test_getBlock } from "../tests/utils";
+import { test_Block, test_getBlock, test_metadataStorage } from "../tests/utils";
 
 test.concurrent("correctly infers the event type", () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	const event = univo.event({
 		id: "test",
@@ -27,7 +31,12 @@ test.concurrent("correctly infers the event type", () => {
 });
 
 test.concurrent("throws an error if an event with an invalid id is defined", () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	expect(() => {
 		univo.event({
@@ -46,7 +55,7 @@ test.concurrent("public_writeUnfinalizedHeads upserts events", async () => {
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
-		metadataStorage: createStorage(),
+		metadataStorage: test_metadataStorage(),
 		getBlock: async (block) => {
 			if (block.number === "finalized") {
 				return block9;
@@ -93,7 +102,7 @@ test.concurrent("public_writeUnfinalizedHeads retries upsert errors", async () =
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
-		metadataStorage: createStorage(),
+		metadataStorage: test_metadataStorage(),
 		getBlock: async (block) => {
 			if (block.number === "finalized") {
 				return block9;
@@ -143,7 +152,7 @@ test.concurrent("public_writeUnfinalizedHeads deduplicates events with the same 
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
-		metadataStorage: createStorage(),
+		metadataStorage: test_metadataStorage(),
 		getBlock: async (block) => {
 			if (block.number === "finalized") {
 				return block9;
@@ -207,7 +216,7 @@ test.concurrent("public_writeUnfinalizedHeads tolerates partial block-load failu
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
-		metadataStorage: createStorage(),
+		metadataStorage: test_metadataStorage(),
 		getBlock: async (block) => {
 			if (block.number === "finalized") {
 				return block9;
@@ -267,7 +276,7 @@ test.concurrent("public_writeUnfinalizedHeads ignores finalized heads", async ()
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
-		metadataStorage: createStorage(),
+		metadataStorage: test_metadataStorage(),
 		getBlock: async (block) => {
 			if (block.number === "finalized") {
 				return block10;
@@ -328,7 +337,7 @@ test.concurrent("public_deleteReorganisedHead deletes events from reorganised bl
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
-		metadataStorage: createStorage(),
+		metadataStorage: test_metadataStorage(),
 		getBlock: async (block) => {
 			if (block.number === "finalized") {
 				return finalized;
@@ -389,7 +398,12 @@ test.concurrent("public_deleteReorganisedHead deletes events from reorganised bl
 test.concurrent("public_deleteReorganisedHead never deletes events from canonical blocks", async () => {
 	const block10 = await test_getBlock({ chain: "0x1", number: numberToHex(10) });
 
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	let deleted = false;
 
@@ -436,7 +450,7 @@ test.concurrent("public_writeFinalizedHeads writes finalized heads", async () =>
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
-		metadataStorage: createStorage(),
+		metadataStorage: test_metadataStorage(),
 		getBlock: async (block) => {
 			if (block.number === "finalized") {
 				if (count === 0) {
@@ -525,7 +539,7 @@ test.concurrent("public_writeFinalizedHeads removes reorganised events", async (
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
-		metadataStorage: createStorage(),
+		metadataStorage: test_metadataStorage(),
 		getBlock: async (block) => {
 			if (block.number === "finalized") {
 				if (count === 0) {
@@ -595,7 +609,12 @@ test.concurrent("public_writeFinalizedHeads removes reorganised events", async (
 });
 
 test.concurrent("public_writeFinalizedHeads throws when receiving heads from different chains", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	await expect(
 		local(univo).request({
@@ -627,7 +646,7 @@ test.concurrent("public_writeFinalizedHeads throws when receiving an unknown hea
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
-		metadataStorage: createStorage(),
+		metadataStorage: test_metadataStorage(),
 		getBlock: async (block) => {
 			if (block.number === "finalized") {
 				return block9;
@@ -678,7 +697,7 @@ test.concurrent("public_writeFinalizedHeads throws if it receives a head greater
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
-		metadataStorage: createStorage(),
+		metadataStorage: test_metadataStorage(),
 		getBlock: async ({ chain, number }) => {
 			if (number === "finalized") {
 				return block10;
@@ -710,7 +729,7 @@ test.concurrent("public_writeFinalizedHeads deletes finalized metadata blocks af
 	const block10 = await test_getBlock({ chain: "0x1", number: numberToHex(10) });
 	const block11 = await test_getBlock({ chain: "0x1", number: numberToHex(11) });
 
-	const metadataStorage = createStorage();
+	const metadataStorage = test_metadataStorage();
 
 	// 1. Chain is finalised at 9
 	// 2. Write unfinalized 10
@@ -758,7 +777,7 @@ test.concurrent("public_writeFinalizedHeads deletes finalized metadata blocks af
 		],
 	});
 
-	expect(await metadataStorage.getKeys("/blocks/v1/0x1")).not.toStrictEqual([]);
+	expect(await metadataStorage.list({ prefix: "/blocks/v1/0x1" }).then((result) => result.items)).not.toStrictEqual([]);
 
 	await local(univo).request({
 		method: "public_writeFinalizedHeads",
@@ -774,7 +793,7 @@ test.concurrent("public_writeFinalizedHeads deletes finalized metadata blocks af
 		],
 	});
 
-	expect(await metadataStorage.getKeys("/blocks/v1/0x1")).toStrictEqual([]);
+	expect(await metadataStorage.list({ prefix: "/blocks/v1/0x1" }).then((result) => result.items)).toStrictEqual([]);
 });
 
 test.concurrent("public_writeFinalizedHeads rejects wrong parent linkage between adjacent finalized heads", async () => {
@@ -784,7 +803,7 @@ test.concurrent("public_writeFinalizedHeads rejects wrong parent linkage between
 	const univo = indexer({
 		quiet: true,
 		signingKey: "test",
-		metadataStorage: createStorage(),
+		metadataStorage: test_metadataStorage(),
 		getBlock: async ({ chain, number }) => {
 			if (number === "finalized") {
 				return block11;
@@ -842,7 +861,7 @@ test.concurrent("public_writeFinalizedHeads is idempotent when called twice with
 	const block10 = await test_getBlock({ chain: "0x1", number: numberToHex(10) });
 	const block11 = await test_getBlock({ chain: "0x1", number: numberToHex(11) });
 
-	const metadataStorage = createStorage();
+	const metadataStorage = test_metadataStorage();
 
 	// 1. Chain is finalized at 9
 	// 2. Write unfinalized 10
@@ -928,7 +947,12 @@ test.concurrent("public_writeFinalizedHeads is idempotent when called twice with
 });
 
 test.concurrent("private_writeEvents indexes only the events requested", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	const upserted: any[] = [];
 	let event2HandlerCalled = false;
@@ -972,7 +996,12 @@ test.concurrent("private_writeEvents indexes only the events requested", async (
 });
 
 test.concurrent("private_writeEvents deduplicates events with the same storage adapter", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	let count = 0;
 	let batch = [] as any[];
@@ -1018,7 +1047,12 @@ test.concurrent("private_writeEvents deduplicates events with the same storage a
 });
 
 test.concurrent("private_writeEvents records events", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1043,7 +1077,12 @@ test.concurrent("private_writeEvents records events", async () => {
 });
 
 test.concurrent("private_writeEvents ignores events not explicitly requested", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1076,7 +1115,12 @@ test.concurrent("private_writeEvents ignores events not explicitly requested", a
 });
 
 test.concurrent("private_writeEvents returns handler errors", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1119,7 +1163,12 @@ test.concurrent("private_writeEvents returns handler errors", async () => {
 });
 
 test.concurrent("private_writeEvents returns errors thrown during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1178,7 +1227,12 @@ test.concurrent("private_writeEvents returns errors thrown during upsert", async
 });
 
 test.concurrent("private_writeEvents retries upsert errors", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	let count = 0;
 
@@ -1242,7 +1296,12 @@ test.concurrent("private_writeEvents retries upsert errors", async () => {
 });
 
 test.concurrent("private_writeEvents only returns the handler error if both handler and upsert fail", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1303,7 +1362,12 @@ test.concurrent("private_writeEvents only returns the handler error if both hand
 });
 
 test.concurrent("private_writeEvents returns incomplete errors in handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1368,7 +1432,12 @@ test.concurrent("private_writeEvents returns incomplete errors in handler", asyn
 });
 
 test.concurrent("private_writeEvents returns swallowed incomplete errors in handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1439,7 +1508,12 @@ test.concurrent("private_writeEvents returns swallowed incomplete errors in hand
 });
 
 test.concurrent("private_writeEvents returns incomplete errors in upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1508,7 +1582,12 @@ test.concurrent("private_writeEvents returns incomplete errors in upsert", async
 });
 
 test.concurrent("private_writeEvents returns swallowed incomplete errors in upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1580,7 +1659,12 @@ test.concurrent("private_writeEvents returns swallowed incomplete errors in upse
 });
 
 test.concurrent("private_writeEvents doesn't return an error when accessing a provided null property", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1620,7 +1704,12 @@ test.concurrent("private_writeEvents doesn't return an error when accessing a pr
 });
 
 test.concurrent("private_writeEvents never upserts if handler returns empty event list", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1651,7 +1740,12 @@ test.concurrent("private_writeEvents never upserts if handler returns empty even
 });
 
 test.concurrent("private_writeEventsAndGetKeys indexes only the events requested", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	const upserted: any[] = [];
 	let event2HandlerCalled = false;
@@ -1711,7 +1805,12 @@ test.concurrent("private_writeEventsAndGetKeys indexes only the events requested
 });
 
 test.concurrent("private_writeEventsAndGetKeys never upserts if handler returns empty event list", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1755,7 +1854,12 @@ test.concurrent("private_writeEventsAndGetKeys never upserts if handler returns 
 });
 
 test.concurrent("private_writeEventsAndGetKeys records minimum keys from matching filters", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1802,7 +1906,12 @@ test.concurrent("private_writeEventsAndGetKeys records minimum keys from matchin
 });
 
 test.concurrent("private_writeEventsAndGetKeys records block keys during handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1850,7 +1959,12 @@ test.concurrent("private_writeEventsAndGetKeys records block keys during handler
 });
 
 test.concurrent("private_writeEventsAndGetKeys records transaction keys during handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1902,7 +2016,12 @@ test.concurrent("private_writeEventsAndGetKeys records transaction keys during h
 });
 
 test.concurrent("private_writeEventsAndGetKeys records withdrawals keys during handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -1954,7 +2073,12 @@ test.concurrent("private_writeEventsAndGetKeys records withdrawals keys during h
 });
 
 test.concurrent("private_writeEventsAndGetKeys records receipt keys during handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2006,7 +2130,12 @@ test.concurrent("private_writeEventsAndGetKeys records receipt keys during handl
 });
 
 test.concurrent("private_writeEventsAndGetKeys records log keys during handler", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2060,7 +2189,12 @@ test.concurrent("private_writeEventsAndGetKeys records log keys during handler",
 });
 
 test.concurrent("private_writeEventsAndGetKeys records block keys during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2113,7 +2247,12 @@ test.concurrent("private_writeEventsAndGetKeys records block keys during upsert"
 });
 
 test.concurrent("private_writeEventsAndGetKeys records transaction keys during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2169,7 +2308,12 @@ test.concurrent("private_writeEventsAndGetKeys records transaction keys during u
 });
 
 test.concurrent("private_writeEventsAndGetKeys records withdrawal keys during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2225,7 +2369,12 @@ test.concurrent("private_writeEventsAndGetKeys records withdrawal keys during up
 });
 
 test.concurrent("private_writeEventsAndGetKeys records receipt keys during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2281,7 +2430,12 @@ test.concurrent("private_writeEventsAndGetKeys records receipt keys during upser
 });
 
 test.concurrent("private_writeEventsAndGetKeys records log keys during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2339,7 +2493,12 @@ test.concurrent("private_writeEventsAndGetKeys records log keys during upsert", 
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full block when using JSON.stringify", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2459,7 +2618,12 @@ test.concurrent("private_writeEventsAndGetKeys records full block when using JSO
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full transactions when using JSON.stringify", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2529,7 +2693,12 @@ test.concurrent("private_writeEventsAndGetKeys records full transactions when us
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full withdrawals when using JSON.stringify", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2580,7 +2749,12 @@ test.concurrent("private_writeEventsAndGetKeys records full withdrawals when usi
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full receipts when using JSON.stringify", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2652,7 +2826,12 @@ test.concurrent("private_writeEventsAndGetKeys records full receipts when using 
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full receipt logs when using JSON.stringify", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2713,7 +2892,12 @@ test.concurrent("private_writeEventsAndGetKeys records full receipt logs when us
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full blocks during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2839,7 +3023,12 @@ test.concurrent("private_writeEventsAndGetKeys records full blocks during upsert
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full transactions during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2915,7 +3104,12 @@ test.concurrent("private_writeEventsAndGetKeys records full transactions during 
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full withdrawals during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -2972,7 +3166,12 @@ test.concurrent("private_writeEventsAndGetKeys records full withdrawals during u
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full receipts during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -3050,7 +3249,12 @@ test.concurrent("private_writeEventsAndGetKeys records full receipts during upse
 });
 
 test.concurrent("private_writeEventsAndGetKeys records full receipt logs during upsert", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",
@@ -3115,7 +3319,12 @@ test.concurrent("private_writeEventsAndGetKeys records full receipt logs during 
 });
 
 test.concurrent("private_writeEventsAndGetKeys returns accessed properties that are undefined", async () => {
-	const univo = indexer({ quiet: true, signingKey: "test", getBlock: test_getBlock, metadataStorage: createStorage() });
+	const univo = indexer({
+		quiet: true,
+		signingKey: "test",
+		getBlock: test_getBlock,
+		metadataStorage: test_metadataStorage(),
+	});
 
 	univo.event({
 		id: "test",

--- a/packages/univo/src/index.ts
+++ b/packages/univo/src/index.ts
@@ -318,7 +318,9 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 
 				const blob = await opts.metadataStorage.download(prefix, { as: "blob" }).catch((error) => {
 					if (error instanceof StorageError) {
-						return null;
+						if (error.code === "NotFound") {
+							return null;
+						}
 					}
 
 					throw error;

--- a/packages/univo/src/index.ts
+++ b/packages/univo/src/index.ts
@@ -1,10 +1,10 @@
-import type { Storage } from "unstorage";
+import { StorageError, type Storage } from "@storagesdk/core";
 
 import { local } from "./transport";
 import type { IndexerRpc } from "./rpc";
 import { version } from "../package.json";
 import { catchException, createException, getException } from "./exceptions";
-import { createLogger, decoder, decompress, hexToNumber, isHexEqual, normalizeHex, retry } from "./utils";
+import { compress, createLogger, decoder, decompress, hexToNumber, isHexEqual, normalizeHex, retry } from "./utils";
 
 /**
  * Block -----------------------------------------------------------------------------------------------------------------------------------
@@ -274,62 +274,77 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 
 	const metadata = {
 		blocks: {
-			async list(head: { chain: `0x${string}`; number?: `0x${string}` }) {
-				let prefix = `/blocks/v1/${normalizeHex(head.chain)}`;
+			async getNextUnfinalizedBlock(chain: `0x${string}`) {
+				const prefix = `blocks/v1/${normalizeHex(chain)}`;
 
-				if (typeof head.number === "string") {
-					prefix += `/${normalizeHex(head.number, 16)}`;
+				const keys = await opts.metadataStorage.list({ prefix, limit: 1 });
+
+				const [key] = keys.items;
+
+				if (key === undefined) {
+					return null;
 				}
 
-				const keys = await opts.metadataStorage.getKeys(prefix);
+				const [_, __, ___, number, hash] = key.path.split("/") as [string, string, string, string, string, string];
 
-				return keys.map((key) => {
-					const [__, ___, chain, number, hash] = key.split(":") as [string, string, string, string, string, string];
-					return { chain, number, hash };
-				});
+				return { chain, number, hash };
 			},
-			async get(head: { chain: `0x${string}`; number?: `0x${string}`; hash?: `0x${string}` }) {
-				let prefix = `/blocks/v1/${head.chain.toLowerCase()}`;
+			async getBlocksByNumber(chain: `0x${string}`, number: `0x${string}`) {
+				const prefix = `blocks/v1/${normalizeHex(chain)}/${normalizeHex(number, 16)}`;
 
-				if (typeof head.number === "string") {
-					prefix += `/${normalizeHex(head.number, 16)}`;
+				const keys = await opts.metadataStorage.list({ prefix });
+
+				// TODO
+				// Technically we need to iterate over the cursors to ensure we read the full list, however in practice
+				// there won't exist more reorganised blocks than what any storage provider would return in a single call
+
+				if (keys.items.length === 0) {
+					return [];
 				}
 
-				if (typeof head.hash === "string") {
-					if (head.number === undefined) {
-						throw new Error("Requested block by hash without specifying a block number");
+				const blocks = await Promise.all(
+					keys.items.map(async (item) => {
+						const blob = await opts.metadataStorage.download(item.path, { as: "blob" });
+						const block = await decompress(blob);
+						const parsed = JSON.parse(block);
+						return parsed as TBlock;
+					}),
+				);
+
+				return blocks;
+			},
+			async getBlockByNumberAndHash(chain: `0x${string}`, number: `0x${string}`, hash: `0x${string}`) {
+				const prefix = `blocks/v1/${normalizeHex(chain)}/${normalizeHex(number, 16)}/${normalizeHex(hash)}`;
+
+				const blob = await opts.metadataStorage.download(prefix, { as: "blob" }).catch((error) => {
+					if (error instanceof StorageError) {
+						return null;
 					}
 
-					prefix += `/${head.hash.toLowerCase()}`;
+					throw error;
+				});
 
-					// When we have the full key we don't perform a prefix search and instead load the key directly
-					const block = await opts.metadataStorage.getItem<TBlock>(prefix);
-
-					if (block === null) {
-						return [];
-					}
-
-					return [block];
+				if (blob === null) {
+					return null;
 				}
 
-				// Otherwise we perform a prefixed search for the values
-				const keys = await opts.metadataStorage.getKeys(prefix);
-				const results = await opts.metadataStorage.getItems<TBlock>(keys);
-
-				return results.map((result) => result.value);
+				const block = await decompress(blob);
+				const parsed = JSON.parse(block);
+				return parsed as TBlock;
 			},
 			async upsert(blocks: TBlock[]) {
 				if (blocks.length === 0) {
 					return;
 				}
 
-				await opts.metadataStorage.setItems(
-					blocks.map((block) => {
+				await Promise.all(
+					blocks.map(async (block) => {
 						const chain = normalizeHex(block.eth_chainId);
 						const hash = normalizeHex(block.eth_getBlockByNumber.hash);
 						const number = normalizeHex(block.eth_getBlockByNumber.number, 16);
-						const key = `/blocks/v1/${chain}/${number}/${hash}`;
-						return { key, value: block };
+						const prefix = `blocks/v1/${chain}/${number}/${hash}`;
+						const compressed = await compress(JSON.stringify(block));
+						await opts.metadataStorage.upload(prefix, compressed);
 					}),
 				);
 			},
@@ -343,7 +358,8 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 						const chain = normalizeHex(block.eth_chainId);
 						const hash = normalizeHex(block.eth_getBlockByNumber.hash);
 						const number = normalizeHex(block.eth_getBlockByNumber.number, 16);
-						await opts.metadataStorage.del(`/blocks/v1/${chain}/${number}/${hash}`);
+						const prefix = `blocks/v1/${chain}/${number}/${hash}`;
+						await opts.metadataStorage.delete(prefix);
 					}),
 				);
 			},
@@ -386,8 +402,8 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 	const GetBlockError = createException("Failed to load block from the provided `getBlock` function");
 
 	const public_getFinalizedHeight = async (chain: `0x${string}`) => {
-		const [[stored], finalizedBlock] = await Promise.all([
-			metadata.blocks.list({ chain }), //
+		const [stored, finalizedBlock] = await Promise.all([
+			metadata.blocks.getNextUnfinalizedBlock(chain), //
 			getBlock({ chain, number: "finalized" }),
 		]);
 
@@ -399,7 +415,7 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 
 		const finalizedHeight = hexToNumber(finalizedBlock.eth_getBlockByNumber.number);
 
-		if (stored === undefined) {
+		if (stored === null) {
 			return finalizedHeight;
 		}
 
@@ -541,12 +557,12 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 		// the canonical chain than this request should yield a block with a different block hash. This is our proof
 		// that this block is no longer included in the chain and that it's safe to delete data associated with it
 
-		const [canonical_block, [stored_block]] = await Promise.all([
+		const [canonical_block, stored_block] = await Promise.all([
 			getBlock({ chain: head.chain, number: head.number }),
-			metadata.blocks.get({ chain: head.chain, number: head.number, hash: head.hash }),
+			metadata.blocks.getBlockByNumberAndHash(head.chain, head.number, head.hash),
 		]);
 
-		if (stored_block === undefined) {
+		if (stored_block === null) {
 			return log.debug("Reorganised block never/already processed");
 		}
 
@@ -660,8 +676,8 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 		// Now we know the heads are valid by themselves, we need to assert their validity in the context of the
 		// metadata and external chain state. We load the current indexer height and the finalized block.
 
-		const [[unfinalizedMetadataBlock], finalizedBlock] = await Promise.all([
-			metadata.blocks.list({ chain }), //
+		const [unfinalizedMetadataBlock, finalizedBlock] = await Promise.all([
+			metadata.blocks.getNextUnfinalizedBlock(chain), //
 			getBlock({ chain, number: "finalized" }),
 		]);
 
@@ -689,7 +705,7 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 		// to return OK to the client and assume the indexer has finalized up to the highest head received. If
 		// we have zero unfinalized blocks to process we early return
 
-		if (unfinalizedMetadataBlock === undefined) {
+		if (unfinalizedMetadataBlock === null) {
 			return log.debug("No heads to finalize, returning...");
 		}
 
@@ -744,7 +760,7 @@ function indexer<TBlock extends Block>(opts: IndexerOptions<TBlock>) {
 			// what the finalized chain processes. So it's likely that this correctness function has no material impact on
 			// the data stored and is just verifies correctness when the chain finalizes
 
-			const processed = await metadata.blocks.get({ chain: head.chain, number: head.number });
+			const processed = await metadata.blocks.getBlocksByNumber(head.chain, head.number);
 
 			if (processed.length === 0) {
 				await writeFinalizedHead(head, null);

--- a/packages/univo/src/index.ts
+++ b/packages/univo/src/index.ts
@@ -1,4 +1,5 @@
-import { StorageError, type Storage } from "@storagesdk/core";
+import { StorageError } from "@storagesdk/core";
+import type { Storage } from "@storagesdk/core";
 
 import { local } from "./transport";
 import type { IndexerRpc } from "./rpc";

--- a/packages/univo/src/utils.ts
+++ b/packages/univo/src/utils.ts
@@ -118,7 +118,12 @@ export async function compress(input: string): Promise<ArrayBuffer> {
 	return new Response(compressed).arrayBuffer();
 }
 
-export async function decompress(input: ArrayBuffer): Promise<string> {
+export async function decompress(input: ArrayBuffer | Blob): Promise<string> {
+	if (input instanceof Blob) {
+		const decompressed = input.stream().pipeThrough(new DecompressionStream("gzip"));
+		return new Response(decompressed).text();
+	}
+
 	const decompressed = new Blob([input]).stream().pipeThrough(new DecompressionStream("gzip"));
 	return new Response(decompressed).text();
 }

--- a/packages/univo/tests/setup.ts
+++ b/packages/univo/tests/setup.ts
@@ -1,8 +1,7 @@
 import { config } from "dotenv";
 import { setupServer } from "msw/node";
 import { http, passthrough } from "msw";
-
-// Environment variables
+import { promises as fs } from "node:fs";
 
 config({ quiet: true });
 
@@ -18,12 +17,22 @@ declare global {
 	}
 }
 
-// Mock service worker
-
 export const server = setupServer(
 	http.all(process.env.TEST_ETHEREUM_RPC_URL, passthrough), //
 );
 
-beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+beforeAll(() => {
+	server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+	server.resetHandlers();
+});
+
+afterAll(async () => {
+	// Close the mocking server
+	server.close();
+
+	// Clear the `.storage` directory which houses our metadata storage
+	await fs.rm("./.storage", { recursive: true, force: true });
+});

--- a/packages/univo/tests/utils.ts
+++ b/packages/univo/tests/utils.ts
@@ -1,5 +1,7 @@
 import { join } from "node:path";
 import { promises as fs } from "node:fs";
+import { Storage } from "@storagesdk/core";
+import { fs as adapter } from "@storagesdk/adapters/fs";
 import type { RpcBlock, RpcTransactionReceipt } from "viem";
 
 import { hexToNumber, retry } from "../src/utils";
@@ -99,4 +101,13 @@ async function saveToCache(cacheDir: string, cacheFile: string, blockData: any) 
 	} catch (error) {
 		//
 	}
+}
+
+export function test_metadataStorage() {
+	return new Storage({
+		adapter: adapter({
+			root: "./.storage",
+			folder: crypto.randomUUID(),
+		}),
+	});
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,19 +14,22 @@ importers:
 
   examples/realtime:
     dependencies:
-      typescript:
-        specifier: ^5
-        version: 5.8.2
       univo:
-        specifier: latest
-        version: 0.1.13
+        specifier: 0.2.14
+        version: 0.2.14(unstorage@1.17.5)
     devDependencies:
-      '@types/bun':
-        specifier: latest
-        version: 1.3.10
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
 
   packages/univo:
     dependencies:
+      '@storagesdk/adapters':
+        specifier: '>=0.6.0'
+        version: 0.6.0(vitest@3.1.3(@types/node@20.11.27)(msw@2.10.2(@types/node@20.11.27)(typescript@5.8.2)))
+      '@storagesdk/core':
+        specifier: '>=0.4.2'
+        version: 0.4.2
       citty:
         specifier: ^0.1.6
         version: 0.1.6
@@ -39,9 +42,6 @@ importers:
       partysocket:
         specifier: ^1.1.3
         version: 1.1.3
-      unstorage:
-        specifier: '>=1'
-        version: 1.17.5
       ws:
         specifier: ^8.18.1
         version: 8.18.1
@@ -653,12 +653,52 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
+  '@storagesdk/adapters@0.6.0':
+    resolution: {integrity: sha512-tunYBBYqHnm5do5+IZN+lkB76eUefajFnUYca879/ncyl2grJkdW6tgdHADA2bK46tseH2hPhqzsXV8JQFWMyQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.0.0
+      '@aws-sdk/lib-storage': ^3.0.0
+      '@aws-sdk/s3-presigned-post': ^3.0.0
+      '@aws-sdk/s3-request-presigner': ^3.0.0
+      '@azure/storage-blob': ^12.0.0
+      '@google-cloud/storage': ^7.0.0
+      '@octokit/rest': ^21.0.0
+      '@tigrisdata/storage': ^3.11.0
+      '@vercel/blob': ^2.3.0
+      vitest: ^4.0.0
+      webdav: ^5.10.0
+    peerDependenciesMeta:
+      '@aws-sdk/client-s3':
+        optional: true
+      '@aws-sdk/lib-storage':
+        optional: true
+      '@aws-sdk/s3-presigned-post':
+        optional: true
+      '@aws-sdk/s3-request-presigner':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@google-cloud/storage':
+        optional: true
+      '@octokit/rest':
+        optional: true
+      '@tigrisdata/storage':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      vitest:
+        optional: true
+      webdav:
+        optional: true
+
+  '@storagesdk/core@0.4.2':
+    resolution: {integrity: sha512-TASJvFpf4tHM52Sgg3AWMF1VsW6tiZAf6cG1PWktyqKWm+P4Iaz8cILEpD1VncvC4DzFYKeXRkq/xgaY3phKtg==}
+    engines: {node: '>=20'}
+
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
-
-  '@types/bun@1.3.10':
-    resolution: {integrity: sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -763,9 +803,6 @@ packages:
     resolution: {integrity: sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  bun-types@1.3.10:
-    resolution: {integrity: sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -1636,9 +1673,11 @@ packages:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
 
-  univo@0.1.13:
-    resolution: {integrity: sha512-xy6luj5Rfni+Qp7Sn7FMkrw+XQUuTQaieIcxHglo+RvZwHokwzTDpQMdOPiDZcjcCBzOn0GUyBCHFI1f688uAQ==}
+  univo@0.2.14:
+    resolution: {integrity: sha512-i8JwRTZCr2bO7+frg6Fn3CTXplUsrex/Q/jLPMYkT6abdzHVWwLluFOjZ+J2ZjJjHRKiygD+F/7r/77ABuO1AQ==}
     hasBin: true
+    peerDependencies:
+      unstorage: '>=1'
 
   unstorage@1.17.5:
     resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
@@ -2221,11 +2260,15 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
-  '@trysound/sax@0.2.0': {}
-
-  '@types/bun@1.3.10':
+  '@storagesdk/adapters@0.6.0(vitest@3.1.3(@types/node@20.11.27)(msw@2.10.2(@types/node@20.11.27)(typescript@5.8.2)))':
     dependencies:
-      bun-types: 1.3.10
+      '@storagesdk/core': 0.4.2
+    optionalDependencies:
+      vitest: 3.1.3(@types/node@20.11.27)(msw@2.10.2(@types/node@20.11.27)(typescript@5.8.2))
+
+  '@storagesdk/core@0.4.2': {}
+
+  '@trysound/sax@0.2.0': {}
 
   '@types/cookie@0.6.0': {}
 
@@ -2329,10 +2372,6 @@ snapshots:
       electron-to-chromium: 1.5.150
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.24.5)
-
-  bun-types@1.3.10:
-    dependencies:
-      '@types/node': 20.11.27
 
   bundle-name@4.1.0:
     dependencies:
@@ -3251,12 +3290,13 @@ snapshots:
 
   universalify@0.2.0: {}
 
-  univo@0.1.13:
+  univo@0.2.14(unstorage@1.17.5):
     dependencies:
       citty: 0.1.6
       dotenv: 17.2.2
       open: 10.2.0
       partysocket: 1.1.3
+      unstorage: 1.17.5
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
This PR migrates the metadata storage interface from `unstorage` to `@storagesdk/core`.

There were three primary issues with unstorage that contributed to this
- First, our application relied on an invariant that the keys inserted into metadata storage could be read in order. There were many adapters that didn't uphold this invariant, and keys would often be returned based on insertion order instead of lexicographical order.
- Secondly, to achieve correctness we need to rely on Compare-And-Swap (CAS) semantics that allow us to read-modify-write values to and from storage. Again, this wasn't something natively supported by unstorage drivers and would have been impossible to build a fully correct system without.
- unstorage offers a wide variety of drivers which were in fact too wide. Drivers for SQL databases come with very different tradeoffs compared to drivers for object storage. A SQL database offers cheaper reads/writes but relatively more expensive storage compared to object storage. Without a consistent set of trade offs for our metadata storage it would be impossible to optimise within those constraints.

The new `@storagesdk/core` from the guys at Tigris solves all these pain points. Object storage is ordered lexicographically, offers the CAS semantics we need, and allows us to collapse onto a single set of tradeoffs to build our metadata layer on top of (cheap storage and expensive read/writes).